### PR TITLE
Add support for mean pooling

### DIFF
--- a/scirepeval.py
+++ b/scirepeval.py
@@ -127,6 +127,7 @@ if __name__ == "__main__":
     parser.add_argument('--adapters-dir', help='path to the adapter checkpoints', default=None)
     parser.add_argument('--fusion-dir', help='path to the fusion checkpoints', default=None)
     parser.add_argument('--adapters-chkpt', help='hf adapter names keyed on tasks', default=None, type=json.loads)
+    parser.add_argument('--pooling-mode',  default="cls", help='Pooling mode to get embeddings from encoder, must be one of "cls" or "mean"')
     parser.add_argument('--output', help="path to the output file", default="scirepeval_results.json")
     parser.add_argument('--fp16', action='store_true', default=False, help='use floating point 16 precision')
     parser.add_argument('--instructor', action='store_true', default=False, help='use an instructor model for eval')
@@ -138,9 +139,16 @@ if __name__ == "__main__":
     elif args.instructor:
         model = InstructorModel(args.model)
     else:
-        model = Model(variant=args.mtype, base_checkpoint=args.model, adapters_load_from=adapters_load_from,
-                      fusion_load_from=args.fusion_dir,
-                      use_ctrl_codes=args.ctrl_tokens,
-                      task_id="", all_tasks=["[CLF]", "[PRX]", "[QRY]", "[RGN]"], use_fp16=args.fp16)
+        model = Model(
+            variant=args.mtype,
+            base_checkpoint=args.model,
+            adapters_load_from=adapters_load_from,
+            fusion_load_from=args.fusion_dir,
+            use_ctrl_codes=args.ctrl_tokens,
+            task_id="",
+            all_tasks=["[CLF]", "[PRX]", "[QRY]", "[RGN]"],
+            pooling_mode=args.pooling_mode,
+            use_fp16=args.fp16
+        )
     evaluator = SciRepEval(tasks_config=args.tasks_config, batch_size=args.batch_size)
     evaluator.evaluate(model, args.output)


### PR DESCRIPTION
This PR adds support for mean pooling. A user simply need to provide the pooling mode like:

```
python scirepeval.py -m allenai/specter --pooling-mode "mean"
```

`pooling_mode` will default to `"cls"`, so behaviour will be unchanged unless user provided `"mean"`. The name `pooling-mode` matches the naming of the corresponding argument in sentence-transformers.

I didn't document this but I am happy to do so if theres an appropriate place to do that!