### PR TITLE
Save intermediate results during benchmarking

### DIFF
--- a/scirepeval.py
+++ b/scirepeval.py
@@ -112,8 +112,8 @@ class SciRepEval:
             for few_shot in few_shot_evaluators:
                 final_results[task_name]["few_shot"].append(
                     {"sample_size": few_shot.sample_size, "results": few_shot.evaluate(embeddings)})
-        with open(output, "w") as f:
-            json.dump(final_results, f, indent=4)
+            with open(output, "w") as f:
+                json.dump(final_results, f, indent=4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
During benchmarking, SciRepEval currently waits until all tasks have been completed to save anything to disk. In my experience, benchmarking can take an extremely long time (8hrs on a V100 with fp16 even without the S2AND tasks) and so a lot of progress can be lost if it crashes at any point before completion. This PR is a simple fix that saves intermediate results as benchmarking progresses.